### PR TITLE
Switch image to node:18-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM rockylinux:8
+FROM node:18-bookworm
 
-RUN dnf -y install python38 python38-yaml python38-jinja2 python38-requests
-
-RUN rpm --import https://dl.google.com/linux/linux_signing_key.pub
-RUN dnf install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm -y
-
-RUN dnf -y module install nodejs:18
+RUN apt-get -y update
+RUN apt-get -y install python3-requests python3-yaml python3-jinja2
+RUN apt-get -y install chromium
 
 RUN groupadd -r automation
 RUN useradd -m -r -g automation -G audio,video automation


### PR DESCRIPTION
- Same image used by the Redash frontend-builder
- Python 3.11
- Install chromium as a shortchut to specifying numerous dependencies