### PR TITLE
Simplify ruff configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ Verify communication with the Redash API
 
     docker run -v $PWD/user-report.yaml:/home/automation/report.yaml -t $IMAGE --dry-run --verbose
 
-Running Unit Tests
-------------------
+Running Checks
+--------------
 
-    python3 -m venv ~/redashvenv1
-    source ~/redashvenv1/bin/activate
+To run lint and unit tests:
+
+    python3 -m venv ~/.venv/redash-email
+    source ~/.venv/redash-email/bin/activate
     pip install -r dev.txt
     npm install
+    make lint
     make check
 
 Running System Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [tool.ruff]
 line-length = 100
-target-version = "py38"
-
-[tool.ruff.lint]
-ignore = ["E501"]
-select = ["C9", "E", "F", "W", "I001", "UP004"]
+target-version = "py311"
 
 [tool.ruff.format]


### PR DESCRIPTION
- Target Python 3.11
- Change venv directory to avoid conflicts with Redash
- Add 'make lint' to README
