### PR TITLE
Leave CSV and PDFs in timestamped directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ WORKDIR /home/automation
 RUN npm -d install puppeteer@22.4.1
 
 COPY --chown=automation:automation src/* /home/automation/
+RUN install -d -o automation -g automation /home/automation/reports
 
 ENTRYPOINT ["/home/automation/send-report.py"]

--- a/src/send-report.py
+++ b/src/send-report.py
@@ -66,10 +66,6 @@ if __name__ == "__main__":
                 len(parameters.keys()) == 1
             ), f"{report['dashboard']}: only one type of parameter may be specified"
             key = list(parameters.keys())[0]
-            assert key not in [
-                "usernames",
-                "volumes",
-            ], f"{report['dashboard']}: '{key}' should not end with 's'"
 
             for parameter in parameters[key]:
                 if parameter:

--- a/src/send-report.py
+++ b/src/send-report.py
@@ -45,11 +45,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--verbose", action="store_true", default=False, help="Print external commands"
     )
-    parser.add_argument(
-        "--share",
-        choices=["enable", "disable"],
-        help="Turn share links on/off. The default is to preserve prior state.",
-    )
     args = parser.parse_args()
 
     cfg = Config.from_file(args.config)
@@ -64,10 +59,6 @@ if __name__ == "__main__":
     for report in cfg["reports"]:
         (dashboard_id, dashboard_slug) = redash.dashboard_id(report["dashboard"])
         public_url = redash_url + urlparse(redash.dashboard_public_url(dashboard_id)).path
-        if args.share == "enable":
-            redash.is_shared[dashboard_id] = True
-        if args.share == "disable":
-            redash.is_shared[dashboard_id] = False
 
         try:
             parameters = report.get("parameters", {None: [None]})  # iterate once

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -8,11 +8,12 @@ log() {
 	fi
 }
 
+tmpdir=$(mktemp -d /tmp/redash-email-test.XXXXX)
 trap 'printf "$0: exit code $? on line $LINENO\n" >&2; exit 1' ERR
-trap 'rm -f $yaml_config' EXIT
+trap 'rm -rf $tmpdir' EXIT
 
 image=redash-email
-yaml_config=/tmp/user-report.yaml
+yaml_config=$tmpdir/user-report.yaml
 redash_api_key=$(docker compose exec postgres psql -At -U postgres -c "SELECT api_key FROM users WHERE email='redash@redash.io'")
 mailto="${USER}@localhost"
 
@@ -45,6 +46,8 @@ reports:
 YAML
 
 log "Execute in container"
-docker run --network redash-email -v $yaml_config:/home/automation/report.yaml -t $image "$@"
+docker run --network redash-email \
+    -v $yaml_config:/home/automation/report.yaml \
+    -t $image "$@"
 
 log "Integration test PASSED"


### PR DESCRIPTION
To allow results to be kept by bind-mounting `/home/automation/reports`

Also:
* Remove assertion for specific parameter names
* Drop `--share` flag