### PR TITLE
Print mail host, scheme, and port number when using --verbose

### DIFF
--- a/src/mailutil.py
+++ b/src/mailutil.py
@@ -39,6 +39,11 @@ class MailUtil:
             elif self.host_url.scheme == "smtps":
                 self.port = 465
 
+    def __repr__(self):
+        return "host {} using {} port {}".format(
+            self.host_url.hostname, self.host_url.scheme.upper(), self.port
+        )
+
     def url_param(self, param, default):
         """Get a parameter from the query string"""
 
@@ -48,7 +53,7 @@ class MailUtil:
         return default
 
     def send_smtp(self):
-        """Open an SMTP connection to relay running on local host"""
+        """Send mail using smtp, smtps, or smtp+tls"""
 
         for hdr in self.headers:  # pylint: disable=C0206
             self.message[hdr] = self.headers[hdr]
@@ -74,8 +79,7 @@ class MailUtil:
         server.quit()
 
     def attach(self, filename, mimetype="application/octet-stream", stream=None):
-        """add an attachment to the email, application/octet-stream
-        :return: Nothing"""
+        """Add an attachment to the email, application/octet-stream"""
 
         first, second = mimetype.split("/")
 
@@ -101,7 +105,7 @@ class MailUtil:
         self.message.attach(part)
 
     def set_body(self, bodytext, msgtype="plain"):
-        """set the message body text"""
+        """Set the message body text"""
         # Use Quoted Printable for body (default is binhex64)
         charset = Charset("utf-8")
         charset.header_encoding = QP
@@ -114,6 +118,6 @@ class MailUtil:
         self.headers[header] = value
 
     def set_headers(self, **kwargs):
-        """set multiple headers at once"""
+        """Set multiple headers at once"""
         for hkey, hvalue in kwargs.items():
             self.set_header(hkey, hvalue)

--- a/src/send-report.py
+++ b/src/send-report.py
@@ -166,6 +166,7 @@ if __name__ == "__main__":
                         sm.attach(csv_filename, mimetype="text/csv")
 
                 if not args.dry_run:
+                    print("Connect to", sm)
                     sm.send_smtp()
         finally:
             redash.dashboard_reset(dashboard_id)

--- a/tests/test_mailutil.py
+++ b/tests/test_mailutil.py
@@ -17,6 +17,17 @@ def test_mail_server_specification():
         )
 
 
+def test_mail_server_repr():
+    smtp_url = "smtp://localhost"
+    sm = MailUtil(
+        smtp_url,
+        From="noreply@redash.io",
+        To="admin@redash.io",
+        Subject="Report",
+    )
+    assert str(sm) == "host localhost using SMTP port 25"
+
+
 def test_mail_server_specification_invalid():
     with pytest.raises(ValueError, match="Mailhost url scheme must be one of"):
         MailUtil(


### PR DESCRIPTION
Useful for identifying cases where a TCP connection can be established, but there is no response.