### PR TITLE
Allow image to be run with arbitrary user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,14 @@ RUN useradd -m -r -g automation -G audio,video automation
 USER automation
 
 WORKDIR /home/automation
+ENV PUPPETEER_CACHE_DIR="/home/automation"
+ENV NODE_PATH="/home/automation/node_modules"
 RUN npm -d install puppeteer@22.8.2
 
 COPY --chown=automation:automation src/* /home/automation/
-RUN install -d -o automation -g automation /home/automation/reports
+RUN install -d -m 1777 -o automation -g automation /home/automation/reports
+
+ENV XDG_CONFIG_HOME=/tmp/.chromium
+ENV XDG_CACHE_HOME=/tmp/.chromium
 
 ENTRYPOINT ["/home/automation/send-report.py"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Verify communication with the Redash API
 
     docker run -v $PWD/user-report.yaml:/home/automation/report.yaml -t $IMAGE --dry-run --verbose
 
+Save a copy of reports by mapping a path to `/reports` and launching as the
+current user
+
+    docker run \
+      --user $(id -u):$(id -g) \
+      -v /var/reports/home/automation/reports \
+      -v /var/reports/user-report.yaml:/home/automation/report.yaml \
+      -t $IMAGE --dry-run
+
 Running Checks
 --------------
 

--- a/src/send-report.py
+++ b/src/send-report.py
@@ -29,6 +29,7 @@ def remember_cwd():
 
 
 if __name__ == "__main__":
+    os.chdir(os.path.dirname(__file__))
     try:
         buildinfo = open(".build", "r", encoding="utf-8").read()  # pylint: disable=R1732
     except FileNotFoundError:

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -47,6 +47,7 @@ YAML
 
 log "Execute in container"
 docker run --network redash-email \
+    --user $(id -u):$(id -g) \
     -v $yaml_config:/home/automation/report.yaml \
     -t $image "$@"
 


### PR DESCRIPTION
* Create reports directory with sticky bit
* Install chrome to a known path
* Use `/tmp` for XDG scratch space
* Adjust current directory to `__file__`