### PR TITLE
Custom scripts for server address and password generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: sudo apt-get -y install pwgen
       - run: make image
       - run: make up
-      - run: make integration-test
+      - run: make integration-tests
       - run: make down

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 IMAGE=redash-email:latest
 PATH:=/usr/lib/postgresql/16/bin:/usr/pgsql-16/bin:$(PATH)
 # values used for integration test
-MYIP != hostname -i
-PASS != pwgen -1s 6
+MYIP != tests/myip.sh
+PASS != tests/pwgen.py 8
 
 image:
 	docker build -t ${IMAGE} -f Dockerfile .
@@ -16,7 +16,7 @@ tests:
 	@PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$$PYTHONPATH:src pytest tests/
 
 .env:
-	printf "REDASH_COOKIE_SECRET=`pwgen -1s 32`\nREDASH_SECRET_KEY=`pwgen -1s 32`\n" >> .env
+	printf "REDASH_COOKIE_SECRET=`tests/pwgen.py 32`\nREDASH_SECRET_KEY=`tests/pwgen.py 32`\n" >> .env
 
 up: .env
 	docker compose up --quiet-pull -d
@@ -27,7 +27,7 @@ up: .env
 	@echo "maildev: http://${MYIP}:1080/"
 	@echo "redash: http://${MYIP}:5001/  # redash@redash.io ${PASS}"
 
-integration-test:
+integration-tests:
 	tests/integration-test.sh --verbose
 
 down:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Running Integration Tests
 
 Install prerequisites:
 
-    apt-get install pwgen docker.io docker-buildx docker-compose-v2
+    apt-get install docker.io docker-buildx docker-compose-v2
 
 To run the tests:
 

--- a/tests/myip.sh
+++ b/tests/myip.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ip route show default | awk '{ print $(NF-2); exit }'

--- a/tests/pwgen.py
+++ b/tests/pwgen.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+import secrets
+import string
+import sys
+
+len = int(sys.argv[1])
+characters = (secrets.choice(string.ascii_letters + string.digits) for _ in range(len))
+print("".join(characters))


### PR DESCRIPTION
* Use interface IP for default gateway
* Avoid pwgen to avoid having to download Debian package list during tests